### PR TITLE
Issue #1 - Corrige erro ao ativar extensão sem nenhum arquivo aberto no editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# Change Log
+## 0.0.4 (27/04/2024)
+* __Bug Fix__: Corrige erro ao ativar extensão sem nenhum arquivo aberto no editor.
 
-All notable changes to the "advpl-parameters-list" extension will be documented in this file.
+## 0.0.3 (11/03/2024)
+* __Feature__: Adicionado icones a arvore de parâmetros.
+* __Bug Fix__: Ajusta expressões regulares padrão para os parâmetros.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## 0.0.2 (09/03/2024)
+* __Docs__: Atualizada documentação adicionando gif animado demonstrando o uso da extensão
+* __Docs__: Atualizada documentação adicionando informações para contribuição ao desenvolvimento da extensão
 
-## [Unreleased]
-
-- Initial release
+## 0.0.1 (09/03/2024)
+* Lançamento inicial da extensão **advpl-parameters-list**. Adiciona suporte para listar e explorar parâmetros diretamente na barra lateral do explorador de arquivos.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 A extensão AdvPL Parameter List oferece uma maneira eficiente de listar e visualizar os parâmetros utilizados no código fonte AdvPL em edição no Visual Studio Code. 
 Desenvolvida especialmente para programadores AdvPL, essa ferramenta simplifica o processo de compreensão e navegação através dos parâmetros de funções e métodos, melhorando a produtividade durante o desenvolvimento.
 
-## Recursos
-
 A extensão **advpl-parameters-list** fornece uma maneira conveniente de navegar e explorar os parâmetros usados em arquivos AdvPL (Advanced Protheus Language) dentro do Visual Studio Code.
 
-### Principais recursos:
+## Recursos Principais
 - **Navegação de Parâmetros**: Navegue rapidamente pelos arquivos AdvPL e vá para a definição dos parâmetros.
 - **Listagem de Parâmetros**: Visualize uma lista de parâmetros usados no arquivo AdvPL atual.
 - **Atualização Dinâmica**: A lista de parâmetros é atualizada automaticamente conforme você edita o arquivo AdvPL.
+
+## Como Usar
+
+Basta abrir um arquivo de código-fonte no Visual Studio Code e visualizar a barra lateral do explorador de arquivos. Você encontrará o menu AdvPL Parâmetros contendo os parâmetros encontradas no arquivo em edição.
 
 ## Amostra
 
@@ -28,16 +30,6 @@ advplParametersList.regex.GetMV: Define expressao regex para busca das chamadas 
 advplParametersList.regex.GetNewPar: Define expressao regex para busca das chamadas a funcao GetNewPar
 advplParametersList.regex.SuperGetMV: Define expressao regex para busca das chamadas a funcao SuperGetMV
 
-## Problemas Conhecidos
-
-Atualmente não há problemas conhecidos com esta extensão. Se encontrar algum problema, por favor, reporte na [página de issues do GitHub](https://github.com/your-username/advpl-parameters-list/issues).
-
-## Notas de Lançamento
-
-### 0.0.1
-
-Lançamento inicial da extensão **advpl-parameters-list**.
-
 ## Contribua
 
 Você pode contribuir com o desenvolvimento desta extensão de várias maneiras:
@@ -46,3 +38,24 @@ Você pode contribuir com o desenvolvimento desta extensão de várias maneiras:
 2. Faça um fork do repositório, faça suas alterações e envie um pull request.
 3. Ajude a melhorar a documentação.
 4. Compartilhe esta extensão com outros desenvolvedores.
+
+## Problemas Conhecidos
+
+Atualmente não há problemas conhecidos com esta extensão. Se encontrar algum problema, por favor, reporte na [página de issues do GitHub](https://github.com/juliansantosinfo/advpl-parameters-list/issues).
+
+## Notas de Lançamento
+
+### 0.0.4 (27/04/2024)
+* __Bug Fix__: Corrige erro ao ativar extensão sem nenhum arquivo aberto no editor.
+
+### 0.0.3 (11/03/2024)
+* __Feature__: Adicionado icones a arvore de parâmetros.
+* __Bug Fix__: Ajusta expressões regulares padrão para os parâmetros.
+
+### 0.0.2 (09/03/2024)
+* __Docs__: Atualizada documentação adicionando gif animado demonstrando o uso da extensão
+* __Docs__: Atualizada documentação adicionando informações para contribuição ao desenvolvimento da extensão
+
+### 0.0.1 (09/03/2024)
+* Lançamento inicial da extensão **advpl-parameters-list**. Adiciona suporte para listar e explorar parâmetros diretamente na barra lateral do explorador de arquivos.
+

--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,12 @@ class SideBarMenuProvider {
       return [];
     }
 
-    const text = activeEditor.document.getText();
+    const textEditor = activeEditor.document.getText();
+    if (textEditor.length === 0) {
+      return [];
+    }
+
+    const text = textEditor;
     const configItems = [];
 
     // Funções para identificar chamadas de função específicas e adicionar seus parâmetros à lista
@@ -144,9 +149,6 @@ function getCallsSuperGetMV(text, configItems) {
 // Função para ativar a extensão
 function activate(context) {
   console.log("Extensão AdvPL Parameters List foi ativada.");
-  vscode.window.showInformationMessage(
-    "Extensão AdvPL Parameters List foi ativada."
-  );
 
   // Criar a barra lateral e registrar a classe como provedor de dados
   const sideBarMenu = vscode.window.createTreeView("sideBarMenu", {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "advpl-parameters-list",
   "displayName": "AdvPL Parameters List",
   "description": "A extensão AdvPL Parameter List oferece uma maneira eficiente de listar e visualizar os parâmetros utilizados no código fonte AdvPL em edição no Visual Studio Code. Desenvolvida especialmente para programadores AdvPL, essa ferramenta simplifica o processo de compreensão e navegação através dos parâmetros de funções e métodos, melhorando a produtividade durante o desenvolvimento.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icon": "images/icon.png",
   "publisher": "JulianSantos",
   "author": {
@@ -28,7 +28,6 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:plaintext",
     "onLanguage:advpl",
     "onLanguage:tlpp"
   ],


### PR DESCRIPTION
Este commit corrige um problema em que a extensão estava lançando um erro ao ser ativada sem nenhum arquivo aberto no editor. Agora, a extensão verifica se há arquivos abertos antes de executar qualquer operação, prevenindo assim o erro.

Resolve a issue #1.